### PR TITLE
octimatch 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![octimatch](http://i.imgur.com/eLKWNj0.png)](http://ionicabizau.github.io/OctiMatch)
 
-# OctiMatch [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/octimatch.svg)](https://www.npmjs.com/package/octimatch) [![Downloads](https://img.shields.io/npm/dt/octimatch.svg)](https://www.npmjs.com/package/octimatch) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# OctiMatch
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/octimatch.svg)](https://www.npmjs.com/package/octimatch) [![Downloads](https://img.shields.io/npm/dt/octimatch.svg)](https://www.npmjs.com/package/octimatch) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > A matching game with GitHub's Octicons.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octimatch",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A matching game with GitHub's Octicons.",
   "main": "js/index.js",
   "scripts": {
@@ -56,6 +56,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
